### PR TITLE
Handle API errors and show empty state when search has no results (fixes #2)

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -3,22 +3,34 @@ import CardList from "../components/CardList";
 import SearchBox from "../components/SearchBox";
 import "./app.css" ;
 import Scroll from "../components/Scroll";
-
+import ErrorBoundry from "./ErrorBoundry";
 
 class App extends Component {
     constructor () {
         super() ;
         this.state = {
             robots : [],
-            searchfield :'' 
+            searchfield :'',
+            isLoading: true,
+            error: null
         }
     }
-    filteredRobots ;
+
+    fetchRobots = () => {
+        this.setState({ isLoading: true, error: null });
+        fetch('https://jsonplaceholder.typicode.com/users')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Failed to load robots (' + response.status + ')');
+            }
+            return response.json();
+        })
+        .then(json => this.setState({ robots: json, isLoading: false, error: null }))
+        .catch(err => this.setState({ error: err.message || 'Failed to load robots', isLoading: false }));
+    }
 
     componentDidMount () {
-        fetch('https://jsonplaceholder.typicode.com/users')
-        .then(response => response.json())
-        .then(json => this.setState({robots : json }))
+        this.fetchRobots();
     }
 
     onSearchChange = (event) => {
@@ -29,19 +41,39 @@ class App extends Component {
         const filteredRobots = this.state.robots.filter( robot => {
             return(robot.name.toLowerCase().includes(this.state.searchfield.toLowerCase())  )
         }) ;
-        if (!this.state.robots.length) {
-            return (<h1>loading ...</h1>)
-        } else {
+        if (this.state.error) {
+            return (
+                <div className="tc" role="alert" aria-live="polite">
+                    <h1 className="f1">ROBOFRIENDS</h1>
+                    <p className="f4 red">Error: {this.state.error}</p>
+                    <button className="pa2 mt2 br2 bg-blue white bn pointer" onClick={this.fetchRobots}>Retry</button>
+                </div>
+            );
+        }
+        if (this.state.isLoading) {
+            return (<h1 aria-live="polite">loading ...</h1>)
+        }
+        if (!filteredRobots.length) {
             return (
                 <div className="tc">
+                    <h1 className="f1">ROBOFRIENDS</h1>
+                    <SearchBox searchChange={this.onSearchChange} />
+                    <p className="f4 gray" aria-live="polite">No robots found for &ldquo;{this.state.searchfield}&rdquo;</p>
+                    <button className="pa2 mt2 br2 bg-blue white bn pointer" onClick={() => this.setState({ searchfield: '' })}>Clear search</button>
+                </div>
+            );
+        }
+        return (
+            <div className="tc">
                 <h1 className="f1">ROBOFRIENDS</h1>
                 <SearchBox searchChange={this.onSearchChange} />
-                <Scroll> 
-                    <CardList robots={filteredRobots} /> 
+                <Scroll>
+                    <ErrorBoundry>
+                        <CardList robots={filteredRobots} />
+                    </ErrorBoundry>
                 </Scroll>
-                </div> ) ;        
-        }
-        
+            </div>
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #2

- Adds isLoading/error to App state; fetchRobots checks response.ok and handles .catch with Retry
- Loading distinct from empty; empty search shows No robots found + Clear search
- CardList wrapped in ErrorBoundry

Test: offline reload shows error+Retry, searching zzzzzzzz shows empty state.