### PR TITLE
fix: add dark/light mode toggle with persistence (fixes #19)

### DIFF
--- a/src/containers/App.darkmode.test.js
+++ b/src/containers/App.darkmode.test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import App from './App';
+
+const mockRobots = [
+  { id: 1, name: 'Leanne Graham', email: 'Sincere@april.biz' },
+  { id: 2, name: 'Ervin Howell', email: 'Shanna@melissa.tv' },
+];
+
+function mockFetchSuccess(data) {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(data) }));
+}
+
+describe('dark mode', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    if (document.body) document.body.removeAttribute('data-theme');
+    delete window.matchMedia;
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders toggle button to switch themes', async () => {
+    mockFetchSuccess(mockRobots);
+    render(<App />);
+    await waitFor(() => expect(screen.getByText('Leanne Graham')).toBeInTheDocument());
+    const toggle = screen.getByTestId('theme-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-label', expect.stringMatching(/Switch to (light|dark) mode/));
+  });
+
+  it('toggles between light and dark and persists to localStorage', async () => {
+    mockFetchSuccess(mockRobots);
+    render(<App />);
+    await waitFor(() => expect(screen.getByText('Leanne Graham')).toBeInTheDocument());
+
+    const toggle = screen.getByTestId('theme-toggle');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(toggle).toHaveTextContent(/Dark/);
+
+    fireEvent.click(toggle);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('robofriends:theme')).toBe('dark');
+    expect(toggle).toHaveTextContent(/Light/);
+    expect(toggle).toHaveAttribute('aria-label', 'Switch to light mode');
+
+    fireEvent.click(toggle);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('robofriends:theme')).toBe('light');
+    expect(toggle).toHaveTextContent(/Dark/);
+  });
+
+  it('loads theme from localStorage on mount', async () => {
+    localStorage.setItem('robofriends:theme', 'dark');
+    mockFetchSuccess(mockRobots);
+    render(<App />);
+    await waitFor(() => expect(screen.getByText('Leanne Graham')).toBeInTheDocument());
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    const toggle = screen.getByTestId('theme-toggle');
+    expect(toggle).toHaveTextContent(/Light/);
+  });
+
+  it('respects prefers-color-scheme when no stored theme', async () => {
+    window.matchMedia = jest.fn().mockImplementation(query => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+    mockFetchSuccess(mockRobots);
+    render(<App />);
+    await waitFor(() => expect(screen.getByText('Leanne Graham')).toBeInTheDocument());
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('toggle is visible in loading and error states', async () => {
+    global.fetch = jest.fn(() => new Promise(() => {}));
+    const { unmount } = render(<App />);
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+    unmount();
+
+    global.fetch = jest.fn(() => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) }));
+    render(<App />);
+    await waitFor(() => expect(screen.getByText(/Error:/)).toBeInTheDocument());
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+  });
+});

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -7,6 +7,33 @@ import ErrorBoundry from "./ErrorBoundry";
 import RobotModal from "../components/RobotModal";
 
 const FAV_KEY = 'robofriends:favorites';
+const THEME_KEY = 'robofriends:theme';
+
+function getInitialTheme() {
+    try {
+        const stored = localStorage.getItem(THEME_KEY);
+        if (stored === 'light' || stored === 'dark') return stored;
+    } catch {}
+    try {
+        if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            return 'dark';
+        }
+    } catch {}
+    return 'light';
+}
+
+function applyTheme(theme) {
+    try {
+        if (typeof document !== 'undefined') {
+            document.documentElement.setAttribute('data-theme', theme);
+            document.documentElement.style.colorScheme = theme;
+            if (document.body) {
+                document.body.setAttribute('data-theme', theme);
+                document.body.dataset.theme = theme;
+            }
+        }
+    } catch {}
+}
 
 function debounce(fn, delay) {
     let timer;
@@ -31,11 +58,13 @@ class App extends Component {
             pageSize: 6,
             selectedRobot: null,
             favorites: [],
-            showFavoritesOnly: false
+            showFavoritesOnly: false,
+            theme: getInitialTheme()
         }
         this.debouncedSetSearch = debounce((val) => {
             this.setState({ debouncedSearchfield: val });
         }, 300);
+        applyTheme(this.state.theme);
     }
 
     fetchRobots = () => {
@@ -61,6 +90,16 @@ class App extends Component {
                 }
             }
         } catch {}
+        try {
+            const storedTheme = localStorage.getItem(THEME_KEY);
+            if ((storedTheme === 'light' || storedTheme === 'dark') && storedTheme !== this.state.theme) {
+                this.setState({ theme: storedTheme });
+            } else {
+                applyTheme(this.state.theme);
+            }
+        } catch {
+            applyTheme(this.state.theme);
+        }
         this.fetchRobots();
     }
 
@@ -70,7 +109,17 @@ class App extends Component {
                 localStorage.setItem(FAV_KEY, JSON.stringify(this.state.favorites));
             } catch {}
         }
+        if (prevState.theme !== this.state.theme) {
+            try {
+                localStorage.setItem(THEME_KEY, this.state.theme);
+            } catch {}
+            applyTheme(this.state.theme);
+        }
     }
+
+    toggleTheme = () => {
+        this.setState(prev => ({ theme: prev.theme === 'dark' ? 'light' : 'dark' }));
+    };
 
     toggleFavorite = (id) => {
         this.setState(prev => ({
@@ -107,7 +156,7 @@ class App extends Component {
     onCloseModal = () => this.setState({ selectedRobot: null });
 
     render () {
-        const { sortBy, sortDir, page: currentPage, pageSize, favorites, showFavoritesOnly } = this.state;
+        const { sortBy, sortDir, page: currentPage, pageSize, favorites, showFavoritesOnly, theme } = this.state;
         const searched = this.state.robots.filter( robot => {
             return(robot.name.toLowerCase().includes(this.state.debouncedSearchfield.toLowerCase())  )
         }) ;
@@ -125,11 +174,26 @@ class App extends Component {
         const page = Math.min(currentPage, totalPages);
         const start = (page - 1) * pageSize;
         const pagedRobots = sorted.slice(start, start + pageSize);
+
+        const themeToggle = (
+            <button
+                aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+                data-testid="theme-toggle"
+                onClick={this.toggleTheme}
+                className="pa2 br2 ba b--green bg-white pointer"
+                title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+                style={{minWidth:'80px'}}
+            >
+                {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
+            </button>
+        );
+
         if (this.state.error) {
             return (
-                <div className="app-root tc" role="alert" aria-live="polite">
-                    <header className="app-header">
+                <div className={`app-root tc theme-${theme}`} data-theme={theme} role="alert" aria-live="polite">
+                    <header className="app-header" style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
                         <h1 className="f1">ROBOFRIENDS</h1>
+                        {themeToggle}
                     </header>
                     <div className="app-main">
                     <p className="f4 red">Error: {this.state.error}</p>
@@ -140,9 +204,10 @@ class App extends Component {
         }
         if (this.state.isLoading) {
             return (
-                <div className="app-root tc">
-                    <header className="app-header">
+                <div className={`app-root tc theme-${theme}`} data-theme={theme}>
+                    <header className="app-header" style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
                         <h1 className="f1">ROBOFRIENDS</h1>
+                        {themeToggle}
                     </header>
                     <div className="loading-container">
                         <h1 aria-live="polite" className="loading-title f1">loading ...</h1>
@@ -173,7 +238,7 @@ class App extends Component {
 
         const sortToolbar = (
             <div className="toolbar">
-                <label htmlFor="sort-select" className="mr2" style={{color:'#e2e8f0', fontWeight:600}}>Sort by</label>
+                <label htmlFor="sort-select" className="mr2" style={{color: theme === 'dark' ? '#e2e8f0' : '#0f172a', fontWeight:600}}>Sort by</label>
                 <select
                     id="sort-select"
                     value={`${sortBy}:${sortDir}`}
@@ -190,9 +255,10 @@ class App extends Component {
 
         if (showFavoritesOnly && favorites.length === 0) {
             return (
-                <div className="app-root tc">
-                    <header className="app-header">
+                <div className={`app-root tc theme-${theme}`} data-theme={theme}>
+                    <header className="app-header" style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
                         <h1 className="f1">ROBOFRIENDS</h1>
+                        {themeToggle}
                     </header>
                     <div className="app-main">
                     <SearchBox
@@ -211,9 +277,10 @@ class App extends Component {
         }
         if (!filteredRobots.length) {
             return (
-                <div className="app-root tc">
-                    <header className="app-header">
+                <div className={`app-root tc theme-${theme}`} data-theme={theme}>
+                    <header className="app-header" style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
                         <h1 className="f1">ROBOFRIENDS</h1>
+                        {themeToggle}
                     </header>
                     <div className="app-main">
                     <SearchBox
@@ -232,9 +299,10 @@ class App extends Component {
             );
         }
         return (
-            <div className="app-root tc">
-                <header className="app-header">
+            <div className={`app-root tc theme-${theme}`} data-theme={theme}>
+                <header className="app-header" style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
                     <h1 className="f1">ROBOFRIENDS</h1>
+                    {themeToggle}
                 </header>
                 <div className="app-main">
                 <SearchBox

--- a/src/containers/app.css
+++ b/src/containers/app.css
@@ -400,3 +400,16 @@ h1 {
     color: #e2e8f0;
     animation: fadeIn 400ms ease-out;
 }
+
+/* Theme toggle integration: ensure header flex layout works */
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* Light theme header text handling */
+body[data-theme='light'] .app-header h1 {
+  color: #0f172a;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,78 @@ code {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }
+
+/* Theme support: dark / light */
+body[data-theme='light'] {
+  --bg-0: #f8fafc;
+  --bg-1: #e0f2fe;
+  --bg-2: #7dd3fc;
+  --card-bg: rgba(255, 255, 255, 0.98);
+  --card-border: rgba(15, 23, 42, 0.08);
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  background:
+    radial-gradient(1200px 600px at 20% -10%, rgba(56, 189, 248, 0.18), transparent 60%),
+    radial-gradient(900px 500px at 90% 0%, rgba(14, 165, 233, 0.14), transparent 60%),
+    linear-gradient(135deg, #e0f2fe 0%, #bae6fd 45%, #7dd3fc 100%);
+  color: #0f172a;
+}
+
+body[data-theme='light'] .app-header {
+  background: rgba(255, 255, 255, 0.82);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+}
+
+body[data-theme='light'] .app-header h1 {
+  background: linear-gradient(180deg, #0f172a 30%, #0284c7 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+body[data-theme='light'] .pagination-info {
+  background: rgba(15, 23, 42, 0.06);
+  color: #0f172a;
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+body[data-theme='light'] .toolbar-btn {
+  background: rgba(15, 23, 42, 0.06);
+  color: #0f172a;
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+body[data-theme='light'] .modern-scroll {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+body[data-theme='light'] .skeleton-card {
+  background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 50%, #e2e8f0 75%);
+}
+
+body[data-theme='dark'] {
+  color: #f8fafc;
+}
+
+/* Dark mode overrides for legacy tachyons classes (used in toggle) */
+body[data-theme='dark'] .bg-white {
+  background-color: #1e293b !important;
+  color: #e2e8f0 !important;
+  border-color: #334155 !important;
+}
+
+body[data-theme='dark'] .b--green {
+  border-color: #475569 !important;
+}
+
+/* Ensure toggle button visible in both themes */
+body[data-theme='light'] [data-testid="theme-toggle"] {
+  background: rgba(15, 23, 42, 0.08) !important;
+  color: #0f172a !important;
+  border-color: rgba(15, 23, 42, 0.12) !important;
+}
+
+body[data-theme='dark'] [data-testid="theme-toggle"] {
+  background: rgba(255, 255, 255, 0.96) !important;
+  color: #0f172a !important;
+}


### PR DESCRIPTION
Closes #19\n\nAdds support for dark and light mode with a button to switch them. Features:\n- Toggle button in header (visible in all states)\n- Persists choice to localStorage (robofriends:theme)\n- Respects system prefers-color-scheme on first load\n- Applies theme via data-theme attribute and CSS variables